### PR TITLE
Added Typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-//Type definitions for syllable
-
 declare function syllable(value: string): number;
 
 export default syllable;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+//Type definitions for syllable
+
+declare function syllable(value: string): number;
+
+export default syllable;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cli.js"
   ],
   "bin": "cli.js",
+  "types": "./index.d.ts",
   "dependencies": {
     "normalize-strings": "^1.1.0",
     "pluralize": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   "files": [
     "problematic.json",
     "index.js",
-    "cli.js"
+    "cli.js",
+    "index.d.ts"
   ],
   "bin": "cli.js",
-  "types": "./index.d.ts",
+  "types": "index.d.ts",
   "dependencies": {
     "normalize-strings": "^1.1.0",
     "pluralize": "^8.0.0"


### PR DESCRIPTION
I added typings to the syllable function for Typescript users. While you can really pass anything to the function since you call the String() function on the parameter, I think the intended type was string. 