### PR TITLE
Anx is a single syllable - issue #46

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var own = {}.hasOwnProperty
 var EXPRESSION_MONOSYLLABIC_ONE = new RegExp(
   [
     'awe($|d|so)',
+    'anx',
     'cia(?:l|$)',
     'tia',
     'cius',

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -196,6 +196,7 @@
   "antiapartheid": 5,
   "antoinette": 3,
   "anyplace": 3,
+  "anxious": 2,
   "anzaldua": 4,
   "aoyama": 3,
   "apace": 2,


### PR DESCRIPTION
Fix for https://github.com/words/syllable/issues/46

Added a fix for the word `anxious` which is 2 syllables as you can see from the google search and dictionaries.

https://www.google.com/search?q=anxious
![image](https://user-images.githubusercontent.com/13316840/96196714-158e1280-0f1e-11eb-99a3-78c21ed17ce3.png)

and
https://www.merriam-webster.com/dictionary/anxious
https://www.dictionary.com/browse/anxious?s=t